### PR TITLE
don't modify the $options hash passed to ->consume

### DIFF
--- a/lib/Queue/Q/ReliableFIFO/Redis.pm
+++ b/lib/Queue/Q/ReliableFIFO/Redis.pm
@@ -481,7 +481,7 @@ SCOPE: {
         my $onerror = $error_subs{$error_action}
             || croak("no handler for $error_action");
 
-        $options ||= {};
+        $options = $options ? {%$options} : {};
         my $chunk       = delete $options->{Chunk} || 1;
         croak("Chunk should be a number > 0") if (! $chunk > 0);
         cluck("DieOnError is deprecated, use ReturnOnDie instead")


### PR DESCRIPTION
Currently if one wants to share the same set of options among multiple consumers it is required to pass different hashrefs to each consumer, because otherwise the first consumer will delete all the keys from the hashref and all the rest will just use default values.
