### PR TITLE
ReliableFIFO now handles binary data correctly and it round trips cleanly. Test cases added to verify functionality.

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,5 +1,8 @@
 Revision history for Perl extension Queue::Q.
 
+  - Change default serializer to Sereal as that gets binary strings
+    correct (unlike JSON::XS). Added test cases.
+
 0.27
   - Add option warn_on_requeue to Queue::Q::ReliableFIFO::Redis to
     make warnings introduced in 0.24 optional by default

--- a/lib/Queue/Q/ReliableFIFO/Item.pm
+++ b/lib/Queue/Q/ReliableFIFO/Item.pm
@@ -6,14 +6,15 @@ use Class::XSAccessor {getters => ['_serialized']};
 
 # for reasons of debugging, JSON is easier, while Sereal::* is
 # faster (about 7%) and delivers smaller serialized blobs.
-use JSON::XS; # use the real stuff, no fall back on pure Perl JSON please
-my $serializer   = JSON::XS->new->utf8->pretty(0);
-my $deserializer = JSON::XS->new->utf8->pretty(0);
+#use JSON::XS; # use the real stuff, no fall back on pure Perl JSON please
+# The JSON::XS doesn't get binary strings quite right. 
+#my $serializer   = JSON::XS->new->utf8->pretty(0);
+#my $deserializer = JSON::XS->new->utf8->pretty(0);
 
-#use Sereal::Encoder;
-#use Sereal::Decoder;
-#my $serializer   = Sereal::Encoder->new();
-#my $deserializer = Sereal::Decoder->new();
+use Sereal::Encoder;
+use Sereal::Decoder;
+my $serializer   = Sereal::Encoder->new();
+my $deserializer = Sereal::Decoder->new();
 
 my @item_info = (
     't',        # time the item was created

--- a/t/240_redis_reliablefifo.t
+++ b/t/240_redis_reliablefifo.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use File::Spec;
 use Test::More;
+use Encode;
 
 use lib (-d 't' ? File::Spec->catdir(qw(t lib)) : 'lib' );
 use Queue::Q::Test;
@@ -21,5 +22,21 @@ isa_ok($q, "Queue::Q::ReliableFIFO");
 isa_ok($q, "Queue::Q::ReliableFIFO::Redis");
 
 Queue::Q::TestReliableFIFO::test_claim_fifo($q);
+
+my $a = pack("C*", 28, 29, 30);
+$q->enqueue_item($a);
+my $item = $q->claim_item();
+$q->mark_item_as_done($item);
+
+is($item->data, $a, "verify roundtrip: " . join(',', unpack("C*", $a)));
+is(Encode::is_utf8($item->data), Encode::is_utf8($a), "Verifying is_utf8 equivalence for ". join(',', unpack("C*", $a)));
+
+$a = pack("C*", 128, 129, 130);
+$q->enqueue_item($a);
+$item = $q->claim_item();
+$q->mark_item_as_done($item);
+
+is($item->data, $a, "verify roundtrip: " . join(',', unpack("C*", $a)));
+is(Encode::is_utf8($item->data), Encode::is_utf8($a), "Verifying is_utf8 equivalence for ". join(',', unpack("C*", $a)));
 
 done_testing();

--- a/t/240_redis_reliablefifo.t
+++ b/t/240_redis_reliablefifo.t
@@ -23,20 +23,19 @@ isa_ok($q, "Queue::Q::ReliableFIFO::Redis");
 
 Queue::Q::TestReliableFIFO::test_claim_fifo($q);
 
-my $a = pack("C*", 28, 29, 30);
-$q->enqueue_item($a);
-my $item = $q->claim_item();
-$q->mark_item_as_done($item);
-
-is($item->data, $a, "verify roundtrip: " . join(',', unpack("C*", $a)));
-is(Encode::is_utf8($item->data), Encode::is_utf8($a), "Verifying is_utf8 equivalence for ". join(',', unpack("C*", $a)));
-
-$a = pack("C*", 128, 129, 130);
-$q->enqueue_item($a);
-$item = $q->claim_item();
-$q->mark_item_as_done($item);
-
-is($item->data, $a, "verify roundtrip: " . join(',', unpack("C*", $a)));
-is(Encode::is_utf8($item->data), Encode::is_utf8($a), "Verifying is_utf8 equivalence for ". join(',', unpack("C*", $a)));
+roundtrip(pack("C*", 28, 29, 30));
+roundtrip(pack("C*", 128, 129, 130));
+roundtrip("\x{1d45b}\x{3a3}");
 
 done_testing();
+
+sub roundtrip {
+    my ($a) = @_;
+
+    $q->enqueue_item($a);
+    my $item = $q->claim_item();
+    $q->mark_item_as_done($item);
+
+    is($item->data, $a, "verify roundtrip: " . join(',', unpack("C*", $a)));
+    is(Encode::is_utf8($item->data), Encode::is_utf8($a), "Verifying is_utf8 equivalence for ". join(',', unpack("C*", $a)));
+}


### PR DESCRIPTION
This PR does two things:

* It adds test cases to make sure that binary data (invalid UTF-8 in particular) is queued/dequeued and ends up as the same. 

* Switches the default serializer in ReliableFIFO/Item.pm to be Sereal -- that actually passes the tests whereas the JSON::XS does not.

You could argue that JSON::XS should be fixed, but that seemed rather daunting. 

This fixes the bug: https://rt.cpan.org/Public/Bug/Display.html?id=94898